### PR TITLE
Styling fix

### DIFF
--- a/paper-radio-button.css
+++ b/paper-radio-button.css
@@ -43,10 +43,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 #offRadio {
   position: absolute;
+  box-sizing: border-box;
   top: 0px;
   left: 0px; 
-  width: 12px;
-  height: 12px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
   border: solid 2px;
   border-color: #5a5a5a;


### PR DESCRIPTION
Greetings!

When viewing the I/O site on Safari, I noticed that something was off when the radio button was selected.

![screen shot 2015-05-27 at 8 01 35 pm](https://cloud.githubusercontent.com/assets/1319720/7850117/964cc142-04ab-11e5-8e9e-738e33aa01ee.png)

The problem exists because there's a global `* { box-sizing: border-box }` CSS rule which `<paper-radio-button>` doesn't accommodate for when there's no Shadow DOM style scoping. This is a good workaround until we have proper style scoping.

Now, back to school...
